### PR TITLE
mouscache-rs: update to redis 0.10

### DIFF
--- a/mouscache/Cargo.toml
+++ b/mouscache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mouscache"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["richer <richer.arc@gmail.com>"]
 description = "A crate to store object either in redis or in memory"
 
@@ -12,6 +12,6 @@ license = "MIT"
 
 [dependencies]
 r2d2 = "0.8"
-redis = "0.9"
+redis = "0.10"
 dns-lookup = "0.9"
 parking_lot = "0.6"

--- a/mouscache/src/redis_cache.rs
+++ b/mouscache/src/redis_cache.rs
@@ -33,8 +33,8 @@ mod r2d2_test {
 
     impl fmt::Display for Error {
         fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-            match self.cause() {
-                Some(cause) => write!(fmt, "{}: {}", self.description(), cause),
+            match self.source() {
+                Some(source) => write!(fmt, "{}: {}", self.description(), source),
                 None => write!(fmt, "{}", self.description()),
             }
         }


### PR DESCRIPTION
Update to redis 0.10
Bump version number to 0.5.4
Fix "warning: use of deprecated item 'std::error::Error::cause': replaced by Error::source, which can support downcasting"